### PR TITLE
Nokogiri updated

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,18 +73,18 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mini_mime (1.1.1)
-    mini_portile2 (2.6.1)
+    mini_portile2 (2.8.0)
     minitest (5.14.4)
     multipart-post (2.1.1)
-    nokogiri (1.12.4)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.13.3)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     parallel (1.20.1)
     parser (3.0.2.0)
       ast (~> 2.4.1)
     powerpack (0.1.3)
     public_suffix (4.0.6)
-    racc (1.5.2)
+    racc (1.6.0)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -159,4 +159,4 @@ DEPENDENCIES
   zendesk_api!
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
This is an update of nokogiri. 

Also, this is will be not used anymore in some time since we are preparing a [PR](https://github.com/ltvco/cancel_from_zendesk/pull/141) to use the original gem. 